### PR TITLE
 fix : references are now set with absolute values. 

### DIFF
--- a/openapi-core/src/main/java/org/openapi4j/core/model/reference/Reference.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/reference/Reference.java
@@ -12,6 +12,8 @@ import java.net.URI;
  * The reference model.
  */
 public class Reference {
+  public static final String ABS_REF_FIELD = "asb$ref";
+
   private static final String CLASS_MISMATCH_ERR_MSG = "Unable to map reference '%s' from class '%s' with class '%s'.";
   private static final String ERR_MSG = "Unable to map reference '%s' content with class '%s'.";
 

--- a/openapi-core/src/main/java/org/openapi4j/core/model/reference/Reference.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/reference/Reference.java
@@ -17,6 +17,8 @@ public class Reference {
 
   // The URI from where the reference expression applies
   private final URI baseUri;
+  // The reference canonical expression
+  private final String canonicalRef;
   // The reference expression
   private final String ref;
   // The raw content of the targeted reference expression
@@ -24,8 +26,9 @@ public class Reference {
   // The mapped content of the targeted reference expression
   private Object mappedContent;
 
-  Reference(URI baseUri, String ref, JsonNode content) {
+  Reference(URI baseUri, String canonicalRef, String ref, JsonNode content) {
     this.baseUri = baseUri;
+    this.canonicalRef = canonicalRef;
     this.ref = ref;
     this.content = content;
   }
@@ -35,6 +38,13 @@ public class Reference {
    */
   URI getBaseUri() {
     return baseUri;
+  }
+
+  /**
+   * Get the canonical reference string
+   */
+  public String getCanonicalRef() {
+    return canonicalRef;
   }
 
   /**

--- a/openapi-core/src/main/java/org/openapi4j/core/model/reference/ReferenceRegistry.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/reference/ReferenceRegistry.java
@@ -9,14 +9,46 @@ import java.util.Map;
  * The reference registry cache
  */
 public class ReferenceRegistry {
+  private URI baseUri;
   private final Map<String, Reference> references = new HashMap<>();
 
-  public void addRef(URI baseUri, String ref) {
-    references.put(ref, new Reference(baseUri, ref, null));
+  public ReferenceRegistry(URI baseUri) {
+    this.baseUri = baseUri;
   }
 
+  public void addRef(URI baseUri, String canonicalRefValue, String refValue) {
+    references.put(canonicalRefValue, new Reference(baseUri, canonicalRefValue, refValue, null));
+  }
+
+  /**
+   * Get the reference from the given reference expression.
+   * The expression
+   * @param ref
+   * @return
+   */
   public Reference getRef(String ref) {
-    return references.get(ref);
+    URI uri = URI.create(ref);
+
+    if (uri.isAbsolute()) {
+      return references.get(ref);
+    }
+
+    // Try to resolve the relative path from base URI
+    return references.get(baseUri.resolve(ref).toString());
+  }
+
+  public Reference getRef(URI baseUri, String ref) {
+    if (baseUri == null) {
+      return getRef(ref);
+    }
+
+    for (Reference reference : references.values()) {
+      if (reference.getBaseUri().equals(baseUri) && reference.getRef().equals(ref)) {
+        return reference;
+      }
+    }
+
+    return null;
   }
 
   public void mergeRefs(ReferenceRegistry registry) {

--- a/openapi-core/src/main/java/org/openapi4j/core/model/reference/ReferenceUri.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/reference/ReferenceUri.java
@@ -1,0 +1,32 @@
+package org.openapi4j.core.model.reference;
+
+import java.net.URI;
+
+class ReferenceUri {
+  private ReferenceUri() {}
+
+  static URI resolve(URI uri, String refValue) {
+    if (refValue == null) {
+      return uri;
+    }
+
+    return uri.resolve(encodeBraces(refValue));
+  }
+
+  static String resolveAsString(URI uri, String refValue) {
+    URI resolvedUri = resolve(uri, refValue);
+    return decodeBraces(resolvedUri.toString());
+  }
+
+  static String encodeBraces(String value) {
+    return value
+      .replace("{", "%7B")
+      .replace("}", "%7D");
+  }
+
+  static String decodeBraces(String value) {
+    return value
+      .replace("%7B", "{")
+      .replace("%7D", "}");
+  }
+}

--- a/openapi-core/src/main/java/org/openapi4j/core/model/v3/OAI3Context.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/v3/OAI3Context.java
@@ -21,7 +21,7 @@ import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.$REF;
 public class OAI3Context implements OAIContext {
   private static final String OPERATION_REF = "operationRef";
 
-  private final ReferenceRegistry referenceRegistry = new ReferenceRegistry();
+  private final ReferenceRegistry referenceRegistry;
   private final URI baseUri;
   private final List<AuthOption> authOptions;
 
@@ -67,6 +67,7 @@ public class OAI3Context implements OAIContext {
    */
   public OAI3Context(URI baseUri, List<AuthOption> authOptions, JsonNode apiNode) throws ResolutionException {
     this.baseUri = baseUri;
+    referenceRegistry = new ReferenceRegistry(baseUri);
     this.authOptions = authOptions;
     resolveReferences(apiNode);
   }
@@ -93,13 +94,13 @@ public class OAI3Context implements OAIContext {
     resolver.resolve();
 
     // Mapping JSON references
-    ReferenceRegistry mappingRefsRegistry = new ReferenceRegistry();
+    ReferenceRegistry mappingRefsRegistry = new ReferenceRegistry(baseUri);
     MappingReferenceResolver mappingResolver = new MappingReferenceResolver(baseUri, authOptions, apiNode, $REF, mappingRefsRegistry);
     mappingResolver.resolve();
     referenceRegistry.mergeRefs(mappingRefsRegistry);
 
     // Links JSON references
-    ReferenceRegistry operationRefsRegistry = new ReferenceRegistry();
+    ReferenceRegistry operationRefsRegistry = new ReferenceRegistry(baseUri);
     ReferenceResolver operationResolver = new ReferenceResolver(baseUri, authOptions, apiNode, OPERATION_REF, operationRefsRegistry);
     operationResolver.resolve();
     referenceRegistry.mergeRefs(operationRefsRegistry);

--- a/openapi-core/src/test/java/org/openapi4j/core/model/reference/ReferenceResolverTest.java
+++ b/openapi-core/src/test/java/org/openapi4j/core/model/reference/ReferenceResolverTest.java
@@ -13,7 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class ReferenceResolverTest {
   @Test(expected = ResolutionException.class)
@@ -68,6 +68,15 @@ public class ReferenceResolverTest {
     OAI3Context apiContext = new OAI3Context(specPath.toURI(), spec);
     Reference reference = apiContext.getReferenceRegistry().getRef("reference2.yaml#/components/parameters/ARef");
     assertNotNull(reference.getContent());
+    Reference sameReference = apiContext.getReferenceRegistry().getRef(null, "reference2.yaml#/components/parameters/ARef");
+    assertNotNull(reference.getContent());
+    assertEquals(reference, sameReference);
+  }
+
+  @Test
+  public void referenceValueNull() throws Exception {
+    URL specPath = getClass().getResource("/reference/valid/reference.yaml");
+    assertEquals(specPath.toURI(), ReferenceUri.resolve(specPath.toURI(), null));
   }
 
   @Test
@@ -75,8 +84,14 @@ public class ReferenceResolverTest {
     URL specPath = getClass().getResource("/reference/valid/identical_relative_ref/api.yaml");
     JsonNode spec = TreeUtil.load(specPath);
     OAI3Context apiContext = new OAI3Context(specPath.toURI(), spec);
-    Reference reference = apiContext.getReferenceRegistry().getRef("reference2.yaml#/components/parameters/ARef");
-    assertNotNull(reference.getContent());
+
+    assertEquals(3, apiContext.getReferenceRegistry().getReferences().size());
+
+    Reference refType1 = apiContext.getReferenceRegistry().getRef("testType.yaml#/TestType");
+    assertNotNull(refType1.getContent());
+    Reference refType2 = apiContext.getReferenceRegistry().getRef("schema2/testType.yaml#/TestType");
+    assertNotNull(refType2.getContent());
+    assertNotEquals(refType1, refType2);
   }
 
   @Test(expected = DecodeException.class)

--- a/openapi-core/src/test/java/org/openapi4j/core/model/reference/ReferenceResolverTest.java
+++ b/openapi-core/src/test/java/org/openapi4j/core/model/reference/ReferenceResolverTest.java
@@ -44,11 +44,15 @@ public class ReferenceResolverTest {
   public void referenceValid() throws Exception {
     URL specPath = getClass().getResource("/reference/valid/reference.yaml");
     OAI3Context apiContext = new OAI3Context(specPath.toURI());
-    Reference reference = apiContext.getReferenceRegistry().getRef("reference2.yaml#/components/parameters/ARef");
+    // From resolved base URI
+    Reference reference = apiContext.getReferenceRegistry().getRef(specPath.toURI().resolve("reference2.yaml"), "reference2.yaml#/components/parameters/ARef");
     assertNotNull(reference.getContent());
     assertNotNull(reference.getMappedContent(Map.class));
     assertNotNull(reference.getMappedContent(LinkedHashMap.class)); // Cache code branch test
     reference.getMappedContent(List.class);
+    // From context/registry base uri
+    reference = apiContext.getReferenceRegistry().getRef("reference2.yaml#/components/parameters/ARef");
+    assertNotNull(reference.getContent());
   }
 
   @Test(expected = ResolutionException.class)
@@ -60,6 +64,15 @@ public class ReferenceResolverTest {
   @Test
   public void referenceValidWithDocument() throws Exception {
     URL specPath = getClass().getResource("/reference/valid/reference.yaml");
+    JsonNode spec = TreeUtil.load(specPath);
+    OAI3Context apiContext = new OAI3Context(specPath.toURI(), spec);
+    Reference reference = apiContext.getReferenceRegistry().getRef("reference2.yaml#/components/parameters/ARef");
+    assertNotNull(reference.getContent());
+  }
+
+  @Test
+  public void referenceWithRelativePathSetupTwice() throws Exception {
+    URL specPath = getClass().getResource("/reference/valid/identical_relative_ref/api.yaml");
     JsonNode spec = TreeUtil.load(specPath);
     OAI3Context apiContext = new OAI3Context(specPath.toURI(), spec);
     Reference reference = apiContext.getReferenceRegistry().getRef("reference2.yaml#/components/parameters/ARef");

--- a/openapi-core/src/test/resources/reference/valid/identical_relative_ref/api.yaml
+++ b/openapi-core/src/test/resources/reference/valid/identical_relative_ref/api.yaml
@@ -1,0 +1,15 @@
+openapi: "3.0.0"
+info:
+  version: 0.1.0
+  title: Broken References Demo API
+  description: Force ReferenceResolver to fail when two $refs with the same string refer to different content
+paths: {}
+components:
+  schemas:
+    Schema1:
+      description: Inline schema with $ref to brokenRefsExample/testType.yaml
+      properties:
+        testType:
+          $ref: 'testType.yaml#/TestType'
+    Schema2:
+      $ref: 'schema2/schema2.yaml#/Schema2'

--- a/openapi-core/src/test/resources/reference/valid/identical_relative_ref/schema2/schema2.yaml
+++ b/openapi-core/src/test/resources/reference/valid/identical_relative_ref/schema2/schema2.yaml
@@ -1,0 +1,5 @@
+Schema2:
+  description: Contains $ref to brokenRefsExample/schema2/testType.yaml
+  properties:
+    testType:
+      $ref: 'testType.yaml#/TestType'

--- a/openapi-core/src/test/resources/reference/valid/identical_relative_ref/schema2/testType.yaml
+++ b/openapi-core/src/test/resources/reference/valid/identical_relative_ref/schema2/testType.yaml
@@ -1,0 +1,5 @@
+TestType:
+  description: A type with a String id
+  properties:
+    id:
+      type: string

--- a/openapi-core/src/test/resources/reference/valid/identical_relative_ref/testType.yaml
+++ b/openapi-core/src/test/resources/reference/valid/identical_relative_ref/testType.yaml
@@ -1,0 +1,5 @@
+TestType:
+  description: A type with a numeric id
+  properties:
+    id:
+      type: integer

--- a/openapi-core/src/test/resources/reference/valid/reference.yaml
+++ b/openapi-core/src/test/resources/reference/valid/reference.yaml
@@ -10,6 +10,7 @@ paths:
         - $ref: '#/components/parameters/EntityId'
         - $ref: 'reference2.yaml#/components/parameters/ARef'
         - $ref: 'reference2.yaml#/components/parameters/BRef'
+        - $ref: 'reference3.yaml'
       responses:
         '200':
           description: The description

--- a/openapi-core/src/test/resources/reference/valid/reference2.yaml
+++ b/openapi-core/src/test/resources/reference/valid/reference2.yaml
@@ -10,4 +10,4 @@ components:
       name: id
       required: true
       schema:
-        $ref: '#/components/schemas/EntityId'
+        $ref: 'reference.yaml#/components/schemas/EntityId'

--- a/openapi-core/src/test/resources/reference/valid/reference3.yaml
+++ b/openapi-core/src/test/resources/reference/valid/reference3.yaml
@@ -1,0 +1,5 @@
+in: path
+name: id
+required: true
+schema:
+  $ref: 'reference.yaml#/components/schemas/EntityId'

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
@@ -6,18 +6,20 @@ import org.openapi4j.core.model.OAIContext;
 import org.openapi4j.core.model.reference.Reference;
 import org.openapi4j.core.util.TreeUtil;
 
+import static org.openapi4j.core.model.reference.Reference.ABS_REF_FIELD;
+
 /**
  * Base class for Open API schema which can be represented as reference.
  */
 public abstract class AbsRefOpenApiSchema<M extends OpenApiSchema<M>> extends AbsOpenApiSchema<M> {
   @JsonProperty("$ref")
   private String ref;
-  @JsonProperty(value = "canonical$ref", access = JsonProperty.Access.WRITE_ONLY)
+  @JsonProperty(value = ABS_REF_FIELD, access = JsonProperty.Access.WRITE_ONLY)
   private String canonicalRef;
 
   // $ref
   public String getRef() {
-    return canonicalRef != null ? canonicalRef : ref;
+    return ref;
   }
 
   public boolean isRef() {
@@ -28,11 +30,23 @@ public abstract class AbsRefOpenApiSchema<M extends OpenApiSchema<M>> extends Ab
     this.ref = ref;
   }
 
+  public void setCanonicalRef(String canonicalRef) {
+    this.canonicalRef = canonicalRef;
+  }
+
+  public String getCanonicalRef() {
+    return canonicalRef;
+  }
+
+  public Reference getReference(OAIContext context) {
+    return context.getReferenceRegistry().getRef(canonicalRef != null ? canonicalRef : ref);
+  }
+
   @SuppressWarnings("unchecked")
   public M copy(OAIContext context, boolean followRefs) {
     if (isRef()) {
       if (followRefs) {
-        Reference reference = context.getReferenceRegistry().getRef(getRef());
+        Reference reference = getReference(context);
         if (reference != null) {
           M copy = (M) TreeUtil.json.convertValue(reference.getContent(), getClass());
           return copy.copy(context, true);

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
@@ -12,10 +12,12 @@ import org.openapi4j.core.util.TreeUtil;
 public abstract class AbsRefOpenApiSchema<M extends OpenApiSchema<M>> extends AbsOpenApiSchema<M> {
   @JsonProperty("$ref")
   private String ref;
+  @JsonProperty(value = "canonical$ref", access = JsonProperty.Access.WRITE_ONLY)
+  private String canonicalRef;
 
   // $ref
   public String getRef() {
-    return ref;
+    return canonicalRef != null ? canonicalRef : ref;
   }
 
   public boolean isRef() {

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/AbsParameter.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/AbsParameter.java
@@ -181,6 +181,7 @@ public abstract class AbsParameter<M extends OpenApiSchema<M>> extends AbsExtend
 
   void copyReference(AbsParameter<M> copy) {
     copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
   }
 
   void copyContent(OAIContext context, AbsParameter<M> copy, boolean followRefs) {

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Callback.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Callback.java
@@ -106,6 +106,7 @@ public class Callback extends AbsRefOpenApiSchema<Callback> {
   protected Callback copyReference(OAIContext context) {
     Callback copy = new Callback();
     copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Link.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Link.java
@@ -119,6 +119,7 @@ public class Link extends AbsExtendedRefOpenApiSchema<Link> {
   protected Link copyReference(OAIContext context) {
     Link copy = new Link();
     copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/RequestBody.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/RequestBody.java
@@ -73,6 +73,7 @@ public class RequestBody extends AbsExtendedRefOpenApiSchema<RequestBody> {
   protected RequestBody copyReference(OAIContext context) {
     RequestBody copy = new RequestBody();
     copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Response.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Response.java
@@ -122,6 +122,7 @@ public class Response extends AbsExtendedRefOpenApiSchema<Response> {
   protected Response copyReference(OAIContext context) {
     Response copy = new Response();
     copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Schema.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Schema.java
@@ -647,6 +647,7 @@ public class Schema extends AbsExtendedRefOpenApiSchema<Schema> {
   protected Schema copyReference(OAIContext context) {
     Schema copy = new Schema();
     copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/CallbackValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/CallbackValidator.java
@@ -20,7 +20,7 @@ class CallbackValidator extends ExpressionValidator<Callback> {
   @Override
   public void validate(OpenApi3 api, Callback callback, ValidationResults results) {
     if (callback.isRef()) {
-      validateReference(api, callback.getRef(), results, $REF, CallbackValidator.instance(), Callback.class);
+      validateReference(api, callback, results, $REF, CallbackValidator.instance(), Callback.class);
     } else {
       validateMap(api, callback.getCallbackPaths(), results, false, null, Regexes.NOEXT_REGEX, PathValidator.instance());
       validateMap(api, callback.getExtensions(), results, false, EXTENSIONS, Regexes.EXT_REGEX, null);

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/ExpressionValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/ExpressionValidator.java
@@ -124,7 +124,7 @@ abstract class ExpressionValidator<M> extends Validator3Base<OpenApi3, M> {
 
     if (pathFragments.length > index) {
       if (schema.isRef()) {
-        schema = api.getContext().getReferenceRegistry().getRef(schema.getRef()).getMappedContent(Schema.class);
+        schema = schema.getReference(api.getContext()).getMappedContent(Schema.class);
       }
 
       if (TYPE_ARRAY.equals(schema.getType())) {

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/HeaderValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/HeaderValidator.java
@@ -29,7 +29,7 @@ class HeaderValidator extends Validator3Base<OpenApi3, Header> {
     // VALIDATION EXCLUSIONS :
     // allowReserved, deprecated, description, example, examples, explode, required
     if (header.isRef()) {
-      validateReference(api, header.getRef(), results, $REF, HeaderValidator.instance(), Header.class);
+      validateReference(api, header, results, $REF, HeaderValidator.instance(), Header.class);
     } else {
       validateString(header.getStyle(), results, false, "simple", STYLE); // Only simple is allowed.
       validateField(api, header.getSchema(), results, false, SCHEMA, SchemaValidator.instance());

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/OpenApiValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/OpenApiValidator.java
@@ -102,7 +102,7 @@ class OpenApiValidator extends Validator3Base<OpenApi3, OpenApi3> {
     String name = null;
 
     if (parameter.isRef()) {
-      Reference reference = api.getContext().getReferenceRegistry().getRef(parameter.getRef());
+      Reference reference = parameter.getReference(api.getContext());
       if (reference != null && reference.getContent() != null) {
         in = reference.getContent().path(IN).textValue();
         required = reference.getContent().path(REQUIRED).booleanValue();

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/OperationValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/OperationValidator.java
@@ -54,7 +54,7 @@ class OperationValidator extends Validator3Base<OpenApi3, Operation> {
 
     for (Callback callback : operation.getCallbacks().values()) {
       if (callback.isRef()) {
-        callback = getReferenceContent(api, callback.getRef(), results, CALLBACKS, Callback.class);
+        callback = getReferenceContent(api, callback, results, CALLBACKS, Callback.class);
       }
 
       if (callback.getCallbackPaths() != null) {

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/ParameterValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/ParameterValidator.java
@@ -49,7 +49,7 @@ class ParameterValidator extends Validator3Base<OpenApi3, Parameter> {
 
     // checks for path params are made with path validator
     if (parameter.isRef()) {
-      validateReference(api, parameter.getRef(), results, $REF, ParameterValidator.instance(), Parameter.class);
+      validateReference(api, parameter, results, $REF, ParameterValidator.instance(), Parameter.class);
     } else {
       validateString(parameter.getName(), results, true, NAME);
       validateString(parameter.getIn(), results, true, Regexes.PARAM_IN_REGEX, IN);

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/RequestBodyValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/RequestBodyValidator.java
@@ -31,7 +31,7 @@ class RequestBodyValidator extends Validator3Base<OpenApi3, RequestBody> {
     // VALIDATION EXCLUSIONS :
     // description, required
     if (requestBody.isRef()) {
-      validateReference(api, requestBody.getRef(), results, $REF, RequestBodyValidator.instance(), RequestBody.class);
+      validateReference(api, requestBody, results, $REF, RequestBodyValidator.instance(), RequestBody.class);
     } else {
       validateMap(api, requestBody.getContentMediaTypes(), results, false, CONTENT, Regexes.NOEXT_REGEX, MediaTypeValidator.instance());
       validateMap(api, requestBody.getExtensions(), results, false, EXTENSIONS, Regexes.EXT_REGEX, null);

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/ResponseValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/ResponseValidator.java
@@ -25,7 +25,7 @@ class ResponseValidator extends Validator3Base<OpenApi3, Response> {
   @Override
   public void validate(OpenApi3 api, Response response, ValidationResults results) {
     if (response.isRef()) {
-      validateReference(api, response.getRef(), results, $REF, ResponseValidator.instance(), Response.class);
+      validateReference(api, response, results, $REF, ResponseValidator.instance(), Response.class);
     } else {
       validateRequired(response.getDescription(), results, true, DESCRIPTION);
       validateMap(api, response.getHeaders(), results, false, HEADERS, null, HeaderValidator.instance());

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/SchemaValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/SchemaValidator.java
@@ -74,7 +74,7 @@ class SchemaValidator extends Validator3Base<OpenApi3, Schema> {
     // example, title, exclusiveMaximum, exclusiveMinimum, nullable, uniqueItems
 
     if (schema.isRef()) {
-      validateReference(api, schema.getRef(), results, $REF, SchemaValidator.instance(), Schema.class);
+      validateReference(api, schema, results, $REF, SchemaValidator.instance(), Schema.class);
     } else {
       validateField(api, schema.getAdditionalProperties(), results, false, ADDITIONALPROPERTIES, SchemaValidator.instance());
       validateField(api, schema.getDiscriminator(), results, false, DISCRIMINATOR, DiscriminatorValidator.instance());
@@ -150,7 +150,7 @@ class SchemaValidator extends Validator3Base<OpenApi3, Schema> {
 
     for (Schema schema : schemas) {
       if (schema.isRef()) {
-        schema = getReferenceContent(api, schema.getRef(), results, DISCRIMINATOR, Schema.class);
+        schema = getReferenceContent(api, schema, results, DISCRIMINATOR, Schema.class);
       }
 
       if (!schema.hasProperty(discriminator.getPropertyName())) {

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/Validator3Base.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/Validator3Base.java
@@ -3,43 +3,45 @@ package org.openapi4j.parser.validation.v3;
 import org.openapi4j.core.exception.DecodeException;
 import org.openapi4j.core.model.reference.Reference;
 import org.openapi4j.core.validation.ValidationResults;
+import org.openapi4j.parser.model.AbsRefOpenApiSchema;
+import org.openapi4j.parser.model.OpenApiSchema;
 import org.openapi4j.parser.model.v3.OpenApi3;
 import org.openapi4j.parser.validation.Validator;
 import org.openapi4j.parser.validation.ValidatorBase;
 
 abstract class Validator3Base<O extends OpenApi3, T> extends ValidatorBase<O, T> {
-  private static final String REF_MISSING = "Missing $ref '%s'";
-  private static final String REF_CONTENT_UNREADABLE = "Unable to read $ref content for '%s' pointer.";
+  protected static final String REF_MISSING = "Missing $ref '%s'";
+  protected static final String REF_CONTENT_UNREADABLE = "Unable to read $ref content for '%s' pointer.";
 
-  <F> F getReferenceContent(final OpenApi3 api,
-                            final String $ref,
-                            final ValidationResults results,
-                            final String crumb,
-                            final Class<F> clazz) {
+  <F extends OpenApiSchema<F>> F getReferenceContent(final OpenApi3 api,
+                                                     final AbsRefOpenApiSchema<F> schema,
+                                                     final ValidationResults results,
+                                                     final String crumb,
+                                                     final Class<F> clazz) {
 
-    Reference reference = api.getContext().getReferenceRegistry().getRef($ref);
+    Reference reference = schema.getReference(api.getContext());
 
     if (reference == null) {
-      results.addError(String.format(REF_MISSING, $ref), crumb);
+      results.addError(String.format(REF_MISSING, schema.getRef()), crumb);
     } else {
       try {
         return reference.getMappedContent(clazz);
       } catch (DecodeException e) {
-        results.addError(String.format(REF_CONTENT_UNREADABLE, $ref), crumb);
+        results.addError(String.format(REF_CONTENT_UNREADABLE, schema.getRef()), crumb);
       }
     }
 
     return null;
   }
 
-  <F> void validateReference(final OpenApi3 api,
-                             final String $ref,
-                             final ValidationResults results,
-                             final String crumb,
-                             final Validator<OpenApi3, F> validator,
-                             final Class<F> clazz) {
+  <F extends OpenApiSchema<F>> void validateReference(final OpenApi3 api,
+                                                      final AbsRefOpenApiSchema<F> schema,
+                                                      final ValidationResults results,
+                                                      final String crumb,
+                                                      final Validator<OpenApi3, F> validator,
+                                                      final Class<F> clazz) {
 
-    F content = getReferenceContent(api, $ref, results, crumb, clazz);
+    F content = getReferenceContent(api, schema, results, crumb, clazz);
     if (content != null) {
       validator.validate(api, content, results);
     }

--- a/openapi-parser/src/test/java/org/openapi4j/parser/model/v3/ModelTest.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/model/v3/ModelTest.java
@@ -459,10 +459,7 @@ public class ModelTest extends Checker {
 
     Parameter parameter = new Parameter();
     parameter.setRef("#/components/parameters/foo");
-    api.getContext().getReferenceRegistry().addRef(
-      api.getContext().getBaseUri(),
-      api.getContext().getBaseUri().resolve(parameter.getRef()).toString(),
-      parameter.getRef());
+    api.getContext().getReferenceRegistry().addRef(api.getContext().getBaseUri(), parameter.getRef());
 
     api.setPath("/foo", new Path().setGet(new Operation().addParameter(parameter)));
     OpenApi3Validator.instance().validate(api);

--- a/openapi-parser/src/test/java/org/openapi4j/parser/model/v3/ModelTest.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/model/v3/ModelTest.java
@@ -459,7 +459,10 @@ public class ModelTest extends Checker {
 
     Parameter parameter = new Parameter();
     parameter.setRef("#/components/parameters/foo");
-    api.getContext().getReferenceRegistry().addRef(api.getContext().getBaseUri(), parameter.getRef());
+    api.getContext().getReferenceRegistry().addRef(
+      api.getContext().getBaseUri(),
+      api.getContext().getBaseUri().resolve(parameter.getRef()).toString(),
+      parameter.getRef());
 
     api.setPath("/foo", new Path().setGet(new Operation().addParameter(parameter)));
     OpenApi3Validator.instance().validate(api);

--- a/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/DiscriminatorValidator.java
+++ b/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/DiscriminatorValidator.java
@@ -12,6 +12,7 @@ import org.openapi4j.schema.validator.ValidationContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.openapi4j.core.model.reference.Reference.ABS_REF_FIELD;
 import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.ALLOF;
 import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.DISCRIMINATOR;
 import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.MAPPING;
@@ -132,7 +133,7 @@ abstract class DiscriminatorValidator extends BaseJsonValidator<OAI3> {
     JsonNode allOfNode = getParentSchemaNode().get(ALLOF);
 
     for (int index = 0; index < allOfNode.size(); ++index) {
-      for (JsonNode refNode : allOfNode.get(index).findValues(OAI3SchemaKeywords.$REF)) {
+      for (JsonNode refNode : allOfNode.get(index).findValues(ABS_REF_FIELD)) {
         Reference reference = context.getContext().getReferenceRegistry().getRef(refNode.textValue());
         discriminatorNode = reference.getContent().get(DISCRIMINATOR);
         if (discriminatorNode != null) {

--- a/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/ReferenceValidator.java
+++ b/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/ReferenceValidator.java
@@ -9,6 +9,8 @@ import org.openapi4j.schema.validator.BaseJsonValidator;
 import org.openapi4j.schema.validator.JsonValidator;
 import org.openapi4j.schema.validator.ValidationContext;
 
+import static org.openapi4j.core.model.reference.Reference.ABS_REF_FIELD;
+
 /**
  * JSON Reference Schema Object validator.
  * This validator is not truly a keyword validator,
@@ -42,7 +44,7 @@ class ReferenceValidator extends BaseJsonValidator<OAI3> {
     if (HASH.equals(refValue)) {
       schemaValidator = parentSchema.findParent();
     } else {
-      Reference reference = context.getContext().getReferenceRegistry().getRef(refValue);
+      Reference reference = context.getContext().getReferenceRegistry().getRef(schemaParentNode.get(ABS_REF_FIELD).textValue());
       // Check visited references to avoid infinite loops
       JsonValidator validator = context.getReference(refValue);
       if (validator == null) {


### PR DESCRIPTION
Related to #28 

This PR introduces JSON references with absolute values.
Those absolute values are injected in loaded documents when discovering $ref fields. This allows spreading the behaviour to all modules by requesting the absolute value instead of $ref value which can be relative in an unknown structure at runtime.

Also, models in parser module are directly filled with this value for manipulation.
Models where $ref field applies can now retrieve the `Reference` object with `getReference(context)` method to avoid fuzzy access to the reference with `getRef()` and new `getCanonicalRef()`.
Notice that those two methods are not tied together. Modifying a ref or the absolute ref by yourself will not update the other. This is already the case with the registry but the purpose of this toolset is not oriented to document generation/serialization.

Parser performance takes a comprehensive hit with this implementation:
```
| Library           | Version       | Time          | Iterations    | Gain    |
|-------------------|---------------|---------------|---------------|---------|
| Swagger           | 2.0.17        | 493,87 ms     | 1             | 1       |
| OpenApi4j         | 0.6-SNAPSHOT  | 284,61 ms     | 1             | 1,74    |
| Swagger           | 2.0.17        | 343,23 ms     | 10            | excl.   |
| OpenApi4j         | 0.6-SNAPSHOT  | 375,64 ms     | 10            | excl.   |
```

Accordingly the modules now always retrieve the absolute value for calculation.