### PR TITLE
fix : Parser - full handling of abs$ref

### DIFF
--- a/openapi-core/src/main/java/org/openapi4j/core/model/OAIContext.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/OAIContext.java
@@ -1,5 +1,7 @@
 package org.openapi4j.core.model;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import org.openapi4j.core.model.reference.ReferenceRegistry;
 
 import java.net.URI;
@@ -17,4 +19,9 @@ public interface OAIContext {
    * @return The base URI of the context.
    */
   URI getBaseUri();
+
+  /**
+   * Get the base document of API description.
+   */
+  JsonNode getBaseDocument();
 }

--- a/openapi-core/src/main/java/org/openapi4j/core/model/reference/AbstractReferenceResolver.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/model/reference/AbstractReferenceResolver.java
@@ -29,7 +29,7 @@ public abstract class AbstractReferenceResolver {
 
   private final URI baseUri;
   private final List<AuthOption> authOptions;
-  private final JsonNode baseDocument;
+  private JsonNode baseDocument;
   private final Map<URI, JsonNode> documentRegistry = new HashMap<>();
   private final ReferenceRegistry referenceRegistry;
   final String refKeyword;
@@ -44,16 +44,20 @@ public abstract class AbstractReferenceResolver {
 
   public void resolve() throws ResolutionException {
     // Register base resolution document
-    JsonNode document
+    baseDocument
       = baseDocument != null
       ? registerDocument(baseUri, baseDocument)
       : registerDocument(baseUri);
 
     // Find all external documents from references
-    findReferences(baseUri, document);
+    findReferences(baseUri, baseDocument);
 
     // Resolves all references
     resolveReferences();
+  }
+
+  public JsonNode getBaseDocument() {
+    return baseDocument;
   }
 
   protected abstract Collection<JsonNode> getReferencePaths(JsonNode document);

--- a/openapi-core/src/main/java/org/openapi4j/core/util/TreeUtil.java
+++ b/openapi-core/src/main/java/org/openapi4j/core/util/TreeUtil.java
@@ -22,7 +22,7 @@ import static java.util.Objects.requireNonNull;
  */
 public final class TreeUtil {
   private static final String URL_REQUIRED_ERR_MSG = "URL is required.";
-  private static final String JSON_ENCODE_ERR_MSG = "Failed to encode as JSON : %s";
+  public static final String JSON_ENCODE_ERR_MSG = "Failed to encode as JSON : %s";
   private static final String YAML_ENCODE_ERR_MSG = "Failed to encode as YAML : %s";
   private static final String DECODE_ERR_MSG = "Failed to decode : %s";
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/OpenApi3Parser.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/OpenApi3Parser.java
@@ -1,6 +1,5 @@
 package org.openapi4j.parser;
 
-import org.openapi4j.core.exception.DecodeException;
 import org.openapi4j.core.exception.ResolutionException;
 import org.openapi4j.core.model.AuthOption;
 import org.openapi4j.core.model.v3.OAI3Context;
@@ -32,9 +31,10 @@ public class OpenApi3Parser extends OpenApiParser<OpenApi3> {
     OpenApi3 api;
 
     try {
-      api = TreeUtil.load(url, authOptions, OpenApi3.class);
-      api.setContext(new OAI3Context(url.toURI()));
-    } catch (DecodeException | URISyntaxException e) {
+      OAI3Context context = new OAI3Context(url.toURI(), authOptions);
+      api = TreeUtil.json.convertValue(context.getBaseDocument(), OpenApi3.class);
+      api.setContext(context);
+    } catch (IllegalArgumentException | URISyntaxException e) {
       throw new ResolutionException(String.format(INVALID_SPEC, url.toString()), e);
     }
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
@@ -1,14 +1,7 @@
 package org.openapi4j.parser.model;
 
-import com.fasterxml.jackson.annotation.JsonFilter;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import org.openapi4j.core.exception.EncodeException;
+import com.fasterxml.jackson.annotation.JsonView;
 import org.openapi4j.core.model.OAIContext;
 import org.openapi4j.core.model.reference.Reference;
 import org.openapi4j.core.util.TreeUtil;
@@ -16,16 +9,15 @@ import org.openapi4j.core.util.TreeUtil;
 import java.net.URI;
 
 import static org.openapi4j.core.model.reference.Reference.ABS_REF_FIELD;
-import static org.openapi4j.core.util.TreeUtil.JSON_ENCODE_ERR_MSG;
 
 /**
  * Base class for Open API schema which can be represented as reference.
  */
-@JsonFilter(ABS_REF_FIELD)
 public abstract class AbsRefOpenApiSchema<M extends OpenApiSchema<M>> extends AbsOpenApiSchema<M> {
   @JsonProperty("$ref")
   private String ref;
   @JsonProperty(value = ABS_REF_FIELD)
+  @JsonView(Views.Internal.class)
   private String canonicalRef;
 
   // $ref

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsRefOpenApiSchema.java
@@ -1,20 +1,39 @@
 package org.openapi4j.parser.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 
+import org.openapi4j.core.exception.EncodeException;
 import org.openapi4j.core.model.OAIContext;
 import org.openapi4j.core.model.reference.Reference;
 import org.openapi4j.core.util.TreeUtil;
 
 import static org.openapi4j.core.model.reference.Reference.ABS_REF_FIELD;
+import static org.openapi4j.core.util.TreeUtil.JSON_ENCODE_ERR_MSG;
 
 /**
  * Base class for Open API schema which can be represented as reference.
  */
 public abstract class AbsRefOpenApiSchema<M extends OpenApiSchema<M>> extends AbsOpenApiSchema<M> {
+  private static final ObjectMapper INTERNAL_MAPPER;
+
+  // Add rule to avoid export of hidden fields
+  static {
+    INTERNAL_MAPPER = new ObjectMapper();
+    INTERNAL_MAPPER.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
+      @Override
+      public boolean hasIgnoreMarker(final AnnotatedMember m) {
+        return ABS_REF_FIELD.equals(m.getName()) || super.hasIgnoreMarker(m);
+      }
+    });
+  }
+
   @JsonProperty("$ref")
   private String ref;
-  @JsonProperty(value = ABS_REF_FIELD, access = JsonProperty.Access.WRITE_ONLY)
+  @JsonProperty(value = ABS_REF_FIELD)
   private String canonicalRef;
 
   // $ref
@@ -40,6 +59,20 @@ public abstract class AbsRefOpenApiSchema<M extends OpenApiSchema<M>> extends Ab
 
   public Reference getReference(OAIContext context) {
     return context.getReferenceRegistry().getRef(canonicalRef != null ? canonicalRef : ref);
+  }
+
+  @Override
+  public JsonNode toNode(OAIContext context, boolean followRefs) throws EncodeException {
+    OpenApiSchema<M> model
+      = followRefs
+      ? copy(context, true)
+      : this;
+
+    try {
+      return INTERNAL_MAPPER.valueToTree(model);
+    } catch (Exception e) {
+      throw new EncodeException(String.format(JSON_ENCODE_ERR_MSG, e.getMessage()));
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/openapi-parser/src/test/java/org/openapi4j/parser/Checker.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/Checker.java
@@ -1,5 +1,6 @@
 package org.openapi4j.parser;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.json.JSONException;
 import org.openapi4j.core.exception.DecodeException;
 import org.openapi4j.core.exception.EncodeException;
@@ -41,11 +42,11 @@ public class Checker {
     return results;
   }
 
-  protected void checkModel(URL resourcePath, OAI api) throws EncodeException, JSONException, DecodeException {
+  protected void checkModel(URL resourcePath, OpenApi3 api) throws EncodeException, JSONException, DecodeException, JsonProcessingException {
     Object obj = TreeUtil.load(resourcePath, Object.class);
     String expected = TreeUtil.toJson(obj);
 
-    String actual = TreeUtil.toJson(api);
+    String actual = TreeUtil.json.writeValueAsString(api.toNode(api.getContext(), false));
 
     JSONAssert.assertEquals(expected, actual, true);
   }

--- a/openapi-parser/src/test/java/org/openapi4j/parser/Checker.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/Checker.java
@@ -43,9 +43,7 @@ public class Checker {
   }
 
   protected void checkModel(URL resourcePath, OpenApi3 api) throws EncodeException, JSONException, DecodeException, JsonProcessingException {
-    Object obj = TreeUtil.load(resourcePath, Object.class);
-    String expected = TreeUtil.toJson(obj);
-
+    String expected = TreeUtil.toJson(TreeUtil.load(resourcePath, OpenApi3.class));
     String actual = TreeUtil.json.writeValueAsString(api.toNode(api.getContext(), false));
 
     JSONAssert.assertEquals(expected, actual, true);

--- a/openapi-parser/src/test/java/org/openapi4j/parser/model/v3/ModelTest.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/model/v3/ModelTest.java
@@ -18,22 +18,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.FORMAT_BINARY;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.FORMAT_DOUBLE;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.FORMAT_FLOAT;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.FORMAT_INT32;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.FORMAT_INT64;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.TYPE_ARRAY;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.TYPE_INTEGER;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.TYPE_NUMBER;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.TYPE_OBJECT;
-import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.TYPE_STRING;
+import static org.junit.Assert.*;
+import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.*;
 
 public class ModelTest extends Checker {
   @Test
@@ -431,35 +417,25 @@ public class ModelTest extends Checker {
     assertEquals(new Parameter().setIn("path"), new Parameter().setIn("path"));
     assertEquals(new Parameter().setName("foo"), new Parameter().setName("foo"));
     assertNotEquals(new Parameter().setName("foo"), new Parameter().setName("bar"));
-
-    Parameter p1 = new Parameter();
-    p1.setRef("#/foo");
-    Parameter p2 = new Parameter();
-    p2.setRef("#/foo");
-    assertEquals(p1, p2);
   }
 
   @Test(expected = ValidationException.class)
   public void invalidReferenceTest() throws Exception {
-    OpenApi3 api = new OpenApi3();
-    api.setContext(new OAI3Context(getClass().getResource("/model/v3/oai-integration/uspto.yaml").toURI()));
+    OpenApi3 api = new OpenApi3Parser().parse(getClass().getResource("/model/v3/oai-integration/uspto.yaml"), true);
 
     Parameter parameter = new Parameter();
-    parameter.setRef("#/wrong");
+    parameter.setReference(api.getContext(), api.getContext().getBaseUri(), "#/wrong");
     api.setPath("/foo", new Path().setGet(new Operation().addParameter(parameter)));
     OpenApi3Validator.instance().validate(api);
   }
 
   @Test(expected = ValidationException.class)
   public void invalidReferenceContentTest() throws Exception {
-    OpenApi3 api = new OpenApi3();
-    api.setContext(new OAI3Context(getClass().getResource("/model/v3/oai-integration/uspto.yaml").toURI()));
+    OpenApi3 api = new OpenApi3Parser().parse(getClass().getResource("/model/v3/oai-integration/uspto.yaml"), true);
 
     api.setComponents(new Components().setParameter("foo", null));
-
     Parameter parameter = new Parameter();
-    parameter.setRef("#/components/parameters/foo");
-    api.getContext().getReferenceRegistry().addRef(api.getContext().getBaseUri(), parameter.getRef());
+    parameter.setReference(api.getContext(), api.getContext().getBaseUri(), "#/components/parameters/foo");
 
     api.setPath("/foo", new Path().setGet(new Operation().addParameter(parameter)));
     OpenApi3Validator.instance().validate(api);

--- a/openapi-parser/src/test/java/org/openapi4j/parser/validation/v3/CommonValidationTest.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/validation/v3/CommonValidationTest.java
@@ -35,7 +35,8 @@ public class CommonValidationTest extends Checker {
     validate("/model/v3/invalid/malformed-spec.yaml");
   }
 
-  @Test(expected = AssertionError.class)
+  // "additionalProperties: foo" is not serialized
+  @Test
   public void additionalPropertiesInvalid() throws Exception {
     validate("/model/v3/invalid/additionalProperties.yaml");
   }


### PR DESCRIPTION
Related to #28 

This PR fixes lacks from previous iteration made in #33:
1. Now parsing from URL/URI is correctly made (and testing method is updated to avoid further regressions).
2. `setRef($ref)` and `setCanonicalRef(abs$ref)` have now lower visibility. To set a reference you now have `setReference(context, uri, $ref)` which will help to keep consistency when writing such value and hide some glue code.
3. `toNode(content, followRefs)` will never export abs$ref field to keep the compliancy with OAI specification. To get the raw document you can use `TreeUtil.toJsonNode(object)`.