### PR TITLE
Support $ref in Path and SecurityScheme

### DIFF
--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsOpenApiSchema.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/AbsOpenApiSchema.java
@@ -2,16 +2,11 @@ package org.openapi4j.parser.model;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.openapi4j.core.exception.EncodeException;
 import org.openapi4j.core.model.OAIContext;
 import org.openapi4j.core.util.TreeUtil;
 
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.openapi4j.core.util.TreeUtil.ENCODE_ERR_MSG;
 

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Path.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/Path.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class Path extends AbsExtendedOpenApiSchema<Path> {
+public class Path extends AbsExtendedRefOpenApiSchema<Path> {
   private String description;
   @JsonAlias({"get", "put", "post", "delete", "options", "head", "patch", "trace"})
   @JsonIgnore
@@ -197,7 +197,7 @@ public class Path extends AbsExtendedOpenApiSchema<Path> {
   }
 
   @Override
-  public Path copy(OAIContext context, boolean followRefs) {
+  public Path copyContent(OAIContext context, boolean followRefs) {
     Path copy = new Path();
 
     copy.setSummary(getSummary());
@@ -207,6 +207,14 @@ public class Path extends AbsExtendedOpenApiSchema<Path> {
     copy.setParameters(copyList(getParameters(), context, followRefs));
     copy.setExtensions(copyMap(getExtensions()));
 
+    return copy;
+  }
+
+  @Override
+  protected Path copyReference(OAIContext context) {
+    Path copy = new Path();
+    copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 }

--- a/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/SecurityScheme.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/model/v3/SecurityScheme.java
@@ -3,7 +3,7 @@ package org.openapi4j.parser.model.v3;
 import org.openapi4j.core.model.OAIContext;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
-public class SecurityScheme extends AbsExtendedOpenApiSchema<SecurityScheme> {
+public class SecurityScheme extends AbsExtendedRefOpenApiSchema<SecurityScheme> {
   private String type;
   private String description;
   private String name;
@@ -94,7 +94,7 @@ public class SecurityScheme extends AbsExtendedOpenApiSchema<SecurityScheme> {
   }
 
   @Override
-  public SecurityScheme copy(OAIContext context, boolean followRefs) {
+  public SecurityScheme copyContent(OAIContext context, boolean followRefs) {
     SecurityScheme copy = new SecurityScheme();
 
     copy.setType(getType());
@@ -107,6 +107,14 @@ public class SecurityScheme extends AbsExtendedOpenApiSchema<SecurityScheme> {
     copy.setOpenIdConnectUrl(getOpenIdConnectUrl());
     copy.setExtensions(copyMap(getExtensions()));
 
+    return copy;
+  }
+
+  @Override
+  protected SecurityScheme copyReference(OAIContext context) {
+    SecurityScheme copy = new SecurityScheme();
+    copy.setRef(getRef());
+    copy.setCanonicalRef(getCanonicalRef());
     return copy;
   }
 }

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/OpenApiValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/OpenApiValidator.java
@@ -15,19 +15,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.COMPONENTS;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.EXTENSIONS;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.EXTERNALDOCS;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.IN;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.INFO;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.NAME;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.OPENAPI;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.PATH;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.PATHS;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.REQUIRED;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.SECURITY;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.SERVERS;
-import static org.openapi4j.parser.validation.v3.OAI3Keywords.TAGS;
+import static org.openapi4j.parser.validation.v3.OAI3Keywords.*;
 
 class OpenApiValidator extends Validator3Base<OpenApi3, OpenApi3> {
   private static final String REQUIRED_PATH_PARAM = "Parameter '%s' in path '%s' must have 'required' property set to true";
@@ -70,7 +58,9 @@ class OpenApiValidator extends Validator3Base<OpenApi3, OpenApi3> {
       String path = pathEntry.getKey();
       final List<String> pathParams = getPathParams(path);
 
-      for (Operation operation : pathEntry.getValue().getOperations().values()) {
+      Path pathItem = pathEntry.getValue();
+      if (pathItem.isRef()) pathItem = getReferenceContent(api, pathItem, results, $REF, Path.class);
+      for (Operation operation : pathItem.getOperations().values()) {
         discoverAndCheckParams(api, path, pathParams, operation.getParameters(), results);
       }
     }

--- a/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/PathValidator.java
+++ b/openapi-parser/src/main/java/org/openapi4j/parser/validation/v3/PathValidator.java
@@ -3,8 +3,10 @@ package org.openapi4j.parser.validation.v3;
 import org.openapi4j.core.validation.ValidationResults;
 import org.openapi4j.parser.model.v3.OpenApi3;
 import org.openapi4j.parser.model.v3.Path;
+import org.openapi4j.parser.model.v3.Schema;
 import org.openapi4j.parser.validation.Validator;
 
+import static org.openapi4j.core.model.v3.OAI3SchemaKeywords.$REF;
 import static org.openapi4j.parser.validation.v3.OAI3Keywords.EXTENSIONS;
 import static org.openapi4j.parser.validation.v3.OAI3Keywords.PARAMETERS;
 import static org.openapi4j.parser.validation.v3.OAI3Keywords.SERVERS;
@@ -21,11 +23,15 @@ class PathValidator extends Validator3Base<OpenApi3, Path> {
 
   @Override
   public void validate(OpenApi3 api, Path path, ValidationResults results) {
-    // VALIDATION EXCLUSIONS :
-    // description, summary
-    validateMap(api, path.getExtensions(), results, false, EXTENSIONS, Regexes.EXT_REGEX, null);
-    validateMap(api, path.getOperations(), results, false, null, Regexes.METHOD_REGEX, OperationValidator.instance());
-    validateList(api, path.getParameters(), results, false, PARAMETERS, ParameterValidator.instance());
-    validateList(api, path.getServers(), results, false, SERVERS, ServerValidator.instance());
+    if (path.isRef()) {
+      validateReference(api, path, results, $REF, PathValidator.instance(), Path.class);
+    } else {
+      // VALIDATION EXCLUSIONS :
+      // description, summary
+      validateMap(api, path.getExtensions(), results, false, EXTENSIONS, Regexes.EXT_REGEX, null);
+      validateMap(api, path.getOperations(), results, false, null, Regexes.METHOD_REGEX, OperationValidator.instance());
+      validateList(api, path.getParameters(), results, false, PARAMETERS, ParameterValidator.instance());
+      validateList(api, path.getServers(), results, false, SERVERS, ServerValidator.instance());
+    }
   }
 }

--- a/openapi-parser/src/test/java/org/openapi4j/parser/validation/v3/PathTest.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/validation/v3/PathTest.java
@@ -1,0 +1,20 @@
+package org.openapi4j.parser.validation.v3;
+
+import org.junit.Test;
+import org.openapi4j.core.validation.ValidationException;
+import org.openapi4j.parser.Checker;
+
+public class PathTest extends Checker {
+  @Test
+  public void testPathWithReference() throws Exception {
+    validate("/validation/v3/path/valid/pathWithReference.yaml");
+  }
+
+  //////////////////////////////////////////////////////////////
+  // INVALID
+  //////////////////////////////////////////////////////////////
+  @Test(expected = ValidationException.class)
+  public void testPathWithReferenceInvalid() throws Exception {
+    validate("/validation/v3/path/invalid/pathWithReference.yaml");
+  }
+}

--- a/openapi-parser/src/test/java/org/openapi4j/parser/validation/v3/SecurityTest.java
+++ b/openapi-parser/src/test/java/org/openapi4j/parser/validation/v3/SecurityTest.java
@@ -15,6 +15,11 @@ public class SecurityTest extends Checker {
     validate("/validation/v3/security/valid/security-root.yaml");
   }
 
+  @Test
+  public void securityWithReference() throws Exception {
+    validate("/validation/v3/security/valid/securityWithReference.yaml");
+  }
+
   //////////////////////////////////////////////////////////////
   // INVALID
   //////////////////////////////////////////////////////////////
@@ -26,5 +31,10 @@ public class SecurityTest extends Checker {
   @Test(expected = ValidationException.class)
   public void securityNoFlowInvalid() throws Exception {
     validate("/validation/v3/security/invalid/securityNoFlow.yaml");
+  }
+
+  @Test(expected = ValidationException.class)
+  public void securityWithReferenceInvalid() throws Exception {
+    validate("/validation/v3/security/invalid/securityWithReference.yaml");
   }
 }

--- a/openapi-parser/src/test/resources/validation/v3/path/invalid/pathWithReference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/path/invalid/pathWithReference.yaml
@@ -1,0 +1,20 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
+# Add required properties in the Open API document object to avoid errors
+openapi: 3.0.0
+info:
+  title: Simple Document
+  version: 0.9.1
+paths:
+  /foo/bar:
+    $ref: 'reference.yaml#/foo_bar'
+  /foo/bar/baz:
+    get:
+      operationId: getFooBar
+      responses:
+        '200':
+          description: The FooBar
+          content:
+            application/json:
+              schema:
+                type: string
+components: {}

--- a/openapi-parser/src/test/resources/validation/v3/path/invalid/reference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/path/invalid/reference.yaml
@@ -1,0 +1,10 @@
+foo_bar:
+  get:
+    operationId: getFooBar_missing_description
+    responses:
+      '200':
+        content:
+          application/json:
+            schema:
+              type: string
+

--- a/openapi-parser/src/test/resources/validation/v3/path/valid/pathWithReference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/path/valid/pathWithReference.yaml
@@ -1,0 +1,20 @@
+﻿# https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#schemaObject
+# Add required properties in the Open API document object to avoid errors
+openapi: 3.0.0
+info:
+  title: Simple Document
+  version: 0.9.1
+paths:
+  /foo/bar:
+    $ref: 'reference.yaml#/foo_bar'
+  /foo/bar/baz:
+    get:
+      operationId: getFooBar
+      responses:
+        '200':
+          description: The FooBar
+          content:
+            application/json:
+              schema:
+                type: string
+components: {}

--- a/openapi-parser/src/test/resources/validation/v3/path/valid/reference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/path/valid/reference.yaml
@@ -1,0 +1,11 @@
+foo_bar:
+  get:
+    operationId: getFooBar
+    responses:
+      '200':
+        description: The FooBar
+        content:
+          application/json:
+            schema:
+              type: string
+

--- a/openapi-parser/src/test/resources/validation/v3/security/invalid/reference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/security/invalid/reference.yaml
@@ -1,0 +1,34 @@
+apiKey:
+  foo: invalid
+http:
+  type: http
+  scheme: basic
+  name: session
+openId:
+  type: openIdConnect
+  openIdConnectUrl: http://example.org/api/openid
+oauth2:
+  type: oauth2
+  flows:
+    authorizationCode:
+      authorizationUrl: https://example.com/api/oauth/dialog
+      tokenUrl: https://example.com/api/oauth/token
+      refreshUrl: https://example.com/api/oauth/token
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets
+    clientCredentials:
+      tokenUrl: https://example.com/api/oauth/token
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets
+    implicit:
+      authorizationUrl: http://example.org/api/oauth/dialog
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets
+    password:
+      tokenUrl: https://example.com/api/oauth/token
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets

--- a/openapi-parser/src/test/resources/validation/v3/security/invalid/securityWithReference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/security/invalid/securityWithReference.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Security
+servers:
+  - url: http://localhost:8080
+paths:
+  /api/apiKey/:
+    post:
+      operationId: apiKey
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: The description
+  /api/http/:
+    post:
+      operationId: http
+      security:
+        - http: []
+      responses:
+        '200':
+          description: The description
+  /api/oauth2/:
+    post:
+      operationId: oauth2
+      security:
+        - oauth2:
+            - write:pets
+      responses:
+        '200':
+          description: The description
+components:
+  securitySchemes:
+    apiKey:
+      $ref: 'reference.yaml#/apiKey'
+    http:
+      $ref: 'reference.yaml#/http'
+    openId:
+      $ref: 'reference.yaml#/openId'
+    oauth2:
+      $ref: 'reference.yaml#/oauth2'
+

--- a/openapi-parser/src/test/resources/validation/v3/security/valid/reference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/security/valid/reference.yaml
@@ -1,0 +1,36 @@
+apiKey:
+  type: apiKey
+  in: cookie
+  name: session
+http:
+  type: http
+  scheme: basic
+  name: session
+openId:
+  type: openIdConnect
+  openIdConnectUrl: http://example.org/api/openid
+oauth2:
+  type: oauth2
+  flows:
+    authorizationCode:
+      authorizationUrl: https://example.com/api/oauth/dialog
+      tokenUrl: https://example.com/api/oauth/token
+      refreshUrl: https://example.com/api/oauth/token
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets
+    clientCredentials:
+      tokenUrl: https://example.com/api/oauth/token
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets
+    implicit:
+      authorizationUrl: http://example.org/api/oauth/dialog
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets
+    password:
+      tokenUrl: https://example.com/api/oauth/token
+      scopes:
+        write:pets: modify pets in your account
+        read:pets: read your pets

--- a/openapi-parser/src/test/resources/validation/v3/security/valid/securityWithReference.yaml
+++ b/openapi-parser/src/test/resources/validation/v3/security/valid/securityWithReference.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Security
+servers:
+  - url: http://localhost:8080
+paths:
+  /api/apiKey/:
+    post:
+      operationId: apiKey
+      security:
+        - apiKey: []
+      responses:
+        '200':
+          description: The description
+  /api/http/:
+    post:
+      operationId: http
+      security:
+        - http: []
+      responses:
+        '200':
+          description: The description
+  /api/oauth2/:
+    post:
+      operationId: oauth2
+      security:
+        - oauth2:
+            - write:pets
+      responses:
+        '200':
+          description: The description
+components:
+  securitySchemes:
+    apiKey:
+      $ref: 'reference.yaml#/apiKey'
+    http:
+      $ref: 'reference.yaml#/http'
+    openId:
+      $ref: 'reference.yaml#/openId'
+    oauth2:
+      $ref: 'reference.yaml#/oauth2'
+


### PR DESCRIPTION
According to the spec, both PathItem and SecurityScheme should allow references.

PathItem:  https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#pathItemObject

SecurityScheme:  https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#componentsObject

