### PR TITLE
fix(validateBody): validate req/res body using media types with params

### DIFF
--- a/openapi-operation-validator/src/main/java/org/openapi4j/operation/validator/validation/OperationValidator.java
+++ b/openapi-operation-validator/src/main/java/org/openapi4j/operation/validator/validation/OperationValidator.java
@@ -314,7 +314,7 @@ public class OperationValidator {
     final Map<String, BodyValidator> validators = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     for (Map.Entry<String, MediaType> entry : mediaTypes.entrySet()) {
-      validators.put(entry.getKey(), new BodyValidator(context, openApi, entry.getValue()));
+      validators.put(ContentType.getTypeOnly(entry.getKey()), new BodyValidator(context, openApi, entry.getValue()));
     }
 
     return validators;

--- a/openapi-operation-validator/src/test/java/org/openapi4j/operation/validator/validation/OperationValidatorTest.java
+++ b/openapi-operation-validator/src/test/java/org/openapi4j/operation/validator/validation/OperationValidatorTest.java
@@ -184,7 +184,7 @@ public class OperationValidatorTest {
     val = loadOperationValidator("postComplexMediaType");
 
     check(
-      new DefaultRequest.Builder(GET, "/complexMediaType").header("Content-Type", "application/json; charset=UTF-8").body(Body.from(body)).build(),
+      new DefaultRequest.Builder(GET, "/complexMediaType").header("Content-Type", "text/plain; charset=iso-8859-1").body(Body.from("dummy")).build(),
       val::validateBody,
       true);
   }
@@ -298,7 +298,7 @@ public class OperationValidatorTest {
     val = loadOperationValidator("getComplexMediaType");
 
     check(
-      new DefaultResponse.Builder(200).header("Content-Type", "application/json; charset=UTF-8").build(),
+      new DefaultResponse.Builder(200).header("Content-Type", "text/plain; charset=iso-8859-1").build(),
       val::validateBody,
       true);
   }

--- a/openapi-operation-validator/src/test/java/org/openapi4j/operation/validator/validation/OperationValidatorTest.java
+++ b/openapi-operation-validator/src/test/java/org/openapi4j/operation/validator/validation/OperationValidatorTest.java
@@ -180,6 +180,13 @@ public class OperationValidatorTest {
       new DefaultRequest.Builder(GET, "/foo").build(),
       val::validateBody,
       false);
+
+    val = loadOperationValidator("postComplexMediaType");
+
+    check(
+      new DefaultRequest.Builder(GET, "/complexMediaType").header("Content-Type", "application/json; charset=UTF-8").body(Body.from(body)).build(),
+      val::validateBody,
+      true);
   }
 
   @Test
@@ -287,6 +294,13 @@ public class OperationValidatorTest {
       new DefaultResponse.Builder(500).header("X-Rate-Limit", "1").build(),
       val::validateHeaders,
       false);
+
+    val = loadOperationValidator("getComplexMediaType");
+
+    check(
+      new DefaultResponse.Builder(200).header("Content-Type", "application/json; charset=UTF-8").build(),
+      val::validateBody,
+      true);
   }
 
   private OperationValidator loadOperationValidator(String opId) {

--- a/openapi-operation-validator/src/test/resources/operation/operationValidator.yaml
+++ b/openapi-operation-validator/src/test/resources/operation/operationValidator.yaml
@@ -83,6 +83,33 @@ paths:
           description: a description
           content:
             'application/json': {}
+  /complexMediaType:
+    get:
+      operationId: getComplexMediaType
+      responses:
+        '200':
+          description: a description
+          content:
+            'application/json; charset=UTF-8':
+            schema:
+              properties:
+                param:
+                  type: string
+    post:
+      operationId: postComplexMediaType
+      requestBody:
+        required: true
+        content:
+          'application/json; charset=UTF-8':
+            schema:
+              properties:
+                param:
+                  type: string
+      responses:
+        '200':
+          description: a description
+          content:
+            'application/json': {}
   /merge_parameters:
     parameters:
       - name: pathStringHeaderParam

--- a/openapi-operation-validator/src/test/resources/operation/operationValidator.yaml
+++ b/openapi-operation-validator/src/test/resources/operation/operationValidator.yaml
@@ -90,21 +90,13 @@ paths:
         '200':
           description: a description
           content:
-            'application/json; charset=UTF-8':
-            schema:
-              properties:
-                param:
-                  type: string
+            'text/plain; charset=iso-8859-1': {}
     post:
       operationId: postComplexMediaType
       requestBody:
         required: true
         content:
-          'application/json; charset=UTF-8':
-            schema:
-              properties:
-                param:
-                  type: string
+          'text/plain; charset=iso-8859-1': {}
       responses:
         '200':
           description: a description


### PR DESCRIPTION
I know there is no charset (or any) parameter required for "application/json" media type (http://www.iana.org/assignments/media-types/application/json) and the UTF-8 is the default encoding (UTF-8, UTF-16.. https://www.ietf.org/rfc/rfc4627.html#section-3) but if an parameter is given like "application/json; charset=UTF-8" I think OperationValidator is not working properly.

In bodyValidator creation process, the validators are stored using their complete media type value as a key map (ex: "application/json; charset=UTF-8")
https://github.com/openapi4j/openapi4j/blob/0309aa57ae50f58bc566828e773583158fdcc317/openapi-operation-validator/src/main/java/org/openapi4j/operation/validator/validation/OperationValidator.java#L317

but when we are validating a body, we only use the type only ("appplication/json") part as key, without parameters, so we cannot recover the stored validator.

https://github.com/openapi4j/openapi4j/blob/0309aa57ae50f58bc566828e773583158fdcc317/openapi-operation-validator/src/main/java/org/openapi4j/operation/validator/validation/OperationValidator.java#L230
