### PR TITLE
Schema validator: Add discriminator value to the error message

### DIFF
--- a/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/DiscriminatorValidator.java
+++ b/openapi-schema-validator/src/main/java/org/openapi4j/schema/validator/v3/DiscriminatorValidator.java
@@ -25,7 +25,7 @@ import static org.openapi4j.core.validation.ValidationSeverity.ERROR;
  * <a href="https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#discriminatorObject" />
  */
 abstract class DiscriminatorValidator extends BaseJsonValidator<OAI3> {
-  private static final ValidationResult INVALID_SCHEMA_ERR = new ValidationResult(ERROR, 1003, "Schema selection can't be made for discriminator '%s'.");
+  private static final ValidationResult INVALID_SCHEMA_ERR = new ValidationResult(ERROR, 1003, "Schema selection can't be made for discriminator '%s' with value '%s'.");
   private static final ValidationResult INVALID_PROPERTY_ERR = new ValidationResult(ERROR, 1004, "Property name in schema is not set.");
   private static final ValidationResult INVALID_PROPERTY_CONTENT_ERR = new ValidationResult(ERROR, 1005, "Property name in content '%s' is not set.");
 
@@ -75,7 +75,7 @@ abstract class DiscriminatorValidator extends BaseJsonValidator<OAI3> {
 
   private void validateAllOf(final JsonNode valueNode, final String discriminatorValue, final ValidationData<?> validation) {
     if (!checkAllOfValidator(discriminatorValue)) {
-      validation.add(CRUMB_INFO, INVALID_SCHEMA_ERR, discriminatorPropertyName);
+      validation.add(CRUMB_INFO, INVALID_SCHEMA_ERR, discriminatorPropertyName, discriminatorValue);
       return;
     }
 
@@ -89,7 +89,7 @@ abstract class DiscriminatorValidator extends BaseJsonValidator<OAI3> {
   private void validateOneAnyOf(final JsonNode valueNode, final String discriminatorValue, final ValidationData<?> validation) {
     SchemaValidator validator = getOneAnyOfValidator(discriminatorValue);
     if (validator == null) {
-      validation.add(CRUMB_INFO, INVALID_SCHEMA_ERR, discriminatorPropertyName);
+      validation.add(CRUMB_INFO, INVALID_SCHEMA_ERR, discriminatorPropertyName, discriminatorValue);
       return;
     }
 


### PR DESCRIPTION
Hey @llfbandit,

I ran into this error message with the schema from https://github.com/openapi4j/openapi4j/issues/95

> `Schema selection can't be made for discriminator 'name'.`

Bus this was quite uninformative and I had to debug manually which of my values in a large array was wrong. I hope this change helps to clarify the message.